### PR TITLE
Fix exporting non-default exports

### DIFF
--- a/fixture/index.js
+++ b/fixture/index.js
@@ -1,1 +1,2 @@
-module.exports.default = '🦄';
+module.exports.default = () => '🦄';
+module.exports.rainbow = '🌈';

--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ const {ConcatSource} = require('webpack-sources');
 module.exports = class AddModuleExportsPlugin {
 	_add(compilation, filename) {
 		const source = `
-const __export__ = module.exports.default;
-module.exports = __export__;
-module.exports.default = __export__;`;
+const __export__ = module.exports;
+module.exports = __export__.default;
+Object.assign(module.exports, __export__);`;
 
 		compilation.assets[filename] = new ConcatSource(compilation.assets[filename], source);
 	}

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,25 @@ module.exports = {
 
 **`output.libraryTarget` must be `commonjs2`**
 
+### Primitive default exports
+
+When exporting a primitive value as default export, other exported values will not be exported anymore. The reason is that this module redeclares the exports as follows.
+
+```js
+module.exports.default = (arg1, arg2) => arg1 + arg2;
+module.exports.subtract = (arg1, arg2) => arg1 - arg2;
+```
+
+This module re-exports them as follows.
+
+```js
+module.exports = (arg1, arg2) => arg1 + arg2;
+module.exports.default = (arg1, arg2) => arg1 + arg2;
+module.exports.subtract = (arg1, arg2) => arg1 - arg2;
+```
+
+Because you can't attach properties to a primitive value, it's not possible to re-export the other properties and so you would end up with only a `module.exports`.
+
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -3,10 +3,14 @@ import webpack from 'webpack';
 import tempy from 'tempy';
 import pify from 'pify';
 
-test(async t => {
+test('add module exports', async t => {
 	const config = require('./fixture/webpack.config');
 	const cwd = tempy.directory();
 	config.output.path = cwd;
 	await pify(webpack)(config);
-	t.is(require(cwd), '🦄');
+
+	const unicorn = require(cwd);
+
+	t.is(unicorn(), '🦄');
+	t.is(unicorn.rainbow, '🌈');
 });


### PR DESCRIPTION
So the thing was with `ow` that I tried to do `import {Predicate} from 'ow';` and extend from `Predicate`. The thing I noticed is that `Predicate` was `undefined` which was weird, because it was definitely exported.

The reason for that was because of this package. Basically what the TypeScript compiler was generating was something like this

```js
module.exports.default = ow;
module.exports.Predicate = Predicate;
module.exports.StringPredicate = StringPredicate;
// etc.
```

After running the code through Webpack and this module, we ended up with exports looking like

```js
module.exports = ow;
module.exports.default = ow;
```

Which means, we loose everything we wanted to export as well.

I fixed it by using an `Object.assign()` copies over all the exported things and we end up with what we wanted to do.

Let me know if you think I'm wrong here, happy to discuss this further :).