### PR TITLE
Add Webpack 5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - '14'
+  - '12'
   - '10'
-  - '8'

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const webpack = require('webpack');
 const {ConcatSource} = require('webpack-sources');
 
 module.exports = class AddModuleExportsPlugin {
@@ -15,20 +16,46 @@ Object.assign(module.exports, __export__);`;
 		compiler.hooks.compilation.tap('AddModuleExportsPlugin', compilation => {
 			const options = compilation.outputOptions;
 
-			if (options.libraryTarget !== 'commonjs2') {
+			let libraryTarget;
+			let hook;
+			let callback;
+			if (Number.parseInt(webpack.version, 10) >= 5) {
+				libraryTarget = options.library.type;
+				hook = compilation.hooks.processAssets;
+
+				callback = (assets, options) => {
+					for (const filename in assets) {
+						if (Object.prototype.hasOwnProperty.call(assets, filename)) {
+							if (filename === options.filename) {
+								this._add(compilation, filename);
+								break;
+							}
+						}
+					}
+				};
+			} else {
+				libraryTarget = options.libraryTarget;
+				hook = compilation.hooks.optimizeChunkAssets;
+
+				callback = (chunks, options) => {
+					for (const chunk of chunks) {
+						for (const filename of chunk.files) {
+							if (filename === options.filename) {
+								this._add(compilation, filename);
+								break;
+							}
+						}
+					}
+				};
+			}
+
+			if (libraryTarget !== 'commonjs2') {
 				compilation.errors.push(new Error('AddModuleExportsPlugin: output.libraryTarget must be `commonjs2`'));
 				return;
 			}
 
-			compilation.hooks.optimizeChunkAssets.tap('AddModuleExportsPlugin', chunks => {
-				for (const chunk of chunks) {
-					for (const filename of chunk.files) {
-						if (filename === options.filename) {
-							this._add(compilation, filename);
-							break;
-						}
-					}
-				}
+			hook.tap('AddModuleExportsPlugin', chunks => {
+				callback(chunks, options);
 			});
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"ava": "^1.4.1",
 		"pify": "^4.0.1",
 		"tempy": "^0.3.0",
-		"webpack": "^4.30.0",
+		"webpack": "^5.1.0",
 		"xo": "^0.24.0"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
In webpack 5:
- libraryTarget is replaced by library.type
- optimizeChunkAssets is deprecated in favour of processAssets

This commit check the version of webpack.
If the version is lower than 5, it uses the old way
and if the version is equal or more than 5, it uses
the new way.